### PR TITLE
fix(mysql): cast PHP booleans to int for bit(1) column bindings

### DIFF
--- a/WebFiori/Database/MySql/MySQLInsertBuilder.php
+++ b/WebFiori/Database/MySql/MySQLInsertBuilder.php
@@ -33,13 +33,14 @@ class MySQLInsertBuilder extends InsertBuilder {
             foreach ($valsArr as $col => $val) {
                 $colObj = $this->getTable()->getColByKey($col);
                 $colType = $colObj->getDatatype();
-                $queryParams['values'][$index][] = $val;
-
                 if ($colType == 'int' || $colType == 'bit' || in_array($colType, Column::BOOL_TYPES)) {
+                    $queryParams['values'][$index][] = (int) $val;
                     $queryParams['bind'] .= 'i';
                 } else if ($colType == 'decimal' || $colType == 'float') {
+                    $queryParams['values'][$index][] = $val;
                     $queryParams['bind'] .= 'd';
                 } else {
+                    $queryParams['values'][$index][] = $val;
                     $queryParams['bind'] .= 's';
                 }
             }

--- a/WebFiori/Database/MySql/MySQLQuery.php
+++ b/WebFiori/Database/MySql/MySQLQuery.php
@@ -41,13 +41,14 @@ class MySQLQuery extends AbstractQuery {
     public function addBinding(Column $col, $value) {
         $colType = $col->getDatatype();
 
-        $this->bindings['values'][] = $value;
-
         if ($colType == 'int' || $colType == 'bit' || in_array($colType, Column::BOOL_TYPES)) {
+            $this->bindings['values'][] = (int) $value;
             $this->bindings['bind'] .= 'i';
         } else if ($colType == 'decimal' || $colType == 'float') {
+            $this->bindings['values'][] = $value;
             $this->bindings['bind'] .= 'd';
         } else {
+            $this->bindings['values'][] = $value;
             $this->bindings['bind'] .= 's';
         }
     }

--- a/tests/WebFiori/Tests/Database/MySql/MySQLQueryBuilderTest.php
+++ b/tests/WebFiori/Tests/Database/MySql/MySQLQueryBuilderTest.php
@@ -2241,4 +2241,75 @@ class MySQLQueryBuilderTest extends TestCase {
         $this->assertEquals(1, $result->getRowsCount());
         $this->assertEquals('Alice', $result->getRows()[0]['name']);
     }
+    /**
+     * @test
+     * Test that PHP booleans are cast to int for BOOL (bit(1)) columns
+     * in single-row insert via MySQLInsertBuilder::parseValues().
+     * @see https://github.com/WebFiori/database/issues/135
+     */
+    public function testInsertBoolColumnCastsToInt() {
+        $schema = new MySQLTestSchema();
+        $schema->table('users_privileges')->insert([
+            'id' => 1,
+            'can-edit-price' => true,
+            'can-change-username' => false,
+            'can-do-anything' => true
+        ]);
+
+        $params = $schema->getQueryGenerator()->getInsertBuilder()->getQueryParams();
+
+        // All boolean values must be integers (1 or 0), not raw PHP booleans
+        $this->assertSame(1, $params['values'][0][1], 'true should be cast to int 1');
+        $this->assertSame(0, $params['values'][0][2], 'false should be cast to int 0');
+        $this->assertSame(1, $params['values'][0][3], 'true should be cast to int 1');
+        $this->assertEquals('iiii', $params['bind']);
+    }
+    /**
+     * @test
+     * Test that PHP booleans are cast to int for BOOL (bit(1)) columns
+     * in update queries via addBinding().
+     * @see https://github.com/WebFiori/database/issues/135
+     */
+    public function testUpdateBoolColumnCastsToInt() {
+        $schema = new MySQLTestSchema();
+        $schema->table('users_privileges')->update([
+            'can-edit-price' => true,
+            'can-change-username' => false,
+        ])->where('id', 1);
+
+        $bindings = $schema->getQueryGenerator()->getBindings();
+
+        // Boolean values must be integers (1 or 0), not raw PHP booleans
+        $this->assertSame(1, $bindings['values'][0], 'true should be cast to int 1');
+        $this->assertSame(0, $bindings['values'][1], 'false should be cast to int 0');
+        $this->assertEquals('iii', $bindings['bind']);
+    }
+    /**
+     * @test
+     * Test that PHP booleans are cast to int for BOOL (bit(1)) columns
+     * in multi-row insert via MySQLInsertBuilder::parseValues().
+     * @see https://github.com/WebFiori/database/issues/135
+     */
+    public function testInsertBoolColumnMultiRowCastsToInt() {
+        $schema = new MySQLTestSchema();
+        $schema->table('users_privileges')->insert([
+            'cols' => ['id', 'can-edit-price', 'can-change-username', 'can-do-anything'],
+            'values' => [
+                [1, true, false, true],
+                [2, false, true, false],
+            ]
+        ]);
+
+        $params = $schema->getQueryGenerator()->getInsertBuilder()->getQueryParams();
+
+        // Row 0
+        $this->assertSame(1, $params['values'][0][1], 'Row 0: true should be cast to int 1');
+        $this->assertSame(0, $params['values'][0][2], 'Row 0: false should be cast to int 0');
+        $this->assertSame(1, $params['values'][0][3], 'Row 0: true should be cast to int 1');
+
+        // Row 1
+        $this->assertSame(0, $params['values'][1][1], 'Row 1: false should be cast to int 0');
+        $this->assertSame(1, $params['values'][1][2], 'Row 1: true should be cast to int 1');
+        $this->assertSame(0, $params['values'][1][3], 'Row 1: false should be cast to int 0');
+    }
 }


### PR DESCRIPTION
# Summary
Cast raw PHP booleans to `(int)` before adding to prepared statement bindings for `bit(1)` columns, fixing "Data too long for column" errors.

## Motivation
Users inserting or updating `DataType::BOOL` columns with PHP `true`/`false` values got MySQL error 1406. Fixes #135.

## Changes
- Cast value to `(int)` in `MySQLQuery::addBinding()` for int/bit/bool types
- Cast value to `(int)` in `MySQLInsertBuilder::parseValues()` for int/bit/bool types
- Added 3 unit tests covering single-row insert, multi-row insert, and update paths

## How to Test / Verify
Unit tests added:
- `testInsertBoolColumnCastsToInt`
- `testUpdateBoolColumnCastsToInt`
- `testInsertBoolColumnMultiRowCastsToInt`

Run: `vendor/bin/phpunit --filter "testInsertBoolColumn|testUpdateBoolColumn"`

## Breaking Changes and Migration Steps
None

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #135