### PR TITLE
feat(schema): add skip/baseline support to SchemaRunner

### DIFF
--- a/WebFiori/Database/Schema/SchemaChangeRepository.php
+++ b/WebFiori/Database/Schema/SchemaChangeRepository.php
@@ -197,7 +197,29 @@ class SchemaChangeRepository extends AbstractRepository {
                 'type' => $change->getType(),
                 'applied-on' => date('Y-m-d H:i:s'),
                 'db-name' => $this->getDatabase()->getConnectionInfo()->getDBName(),
-                'batch' => $change->getBatch()
+                'batch' => $change->getBatch(),
+                'status' => 'applied'
+            ])->execute();
+
+        return $this->getLastInsertId();
+    }
+
+    /**
+     * Record a change as skipped (baselined).
+     * 
+     * @param DatabaseChange $change The change to record
+     * @param int $batch The batch number to assign
+     * @return int The ID of the inserted record
+     */
+    public function recordSkipped(DatabaseChange $change, int $batch): int {
+        $this->getDatabase()->table($this->getTableName())
+            ->insert([
+                'change_name' => $change->getName(),
+                'type' => $change->getType(),
+                'applied-on' => date('Y-m-d H:i:s'),
+                'db-name' => $this->getDatabase()->getConnectionInfo()->getDBName(),
+                'batch' => $batch,
+                'status' => 'skipped'
             ])->execute();
 
         return $this->getLastInsertId();

--- a/WebFiori/Database/Schema/SchemaMigrationsTable.php
+++ b/WebFiori/Database/Schema/SchemaMigrationsTable.php
@@ -59,5 +59,12 @@ use WebFiori\Database\DataType;
     default: 1,
     comment: 'The batch number when this change was applied.'
 )]
+#[Column(
+    name: 'status',
+    type: DataType::VARCHAR,
+    size: 20,
+    default: 'applied',
+    comment: 'Status of the change: applied or skipped.'
+)]
 class SchemaMigrationsTable {
 }

--- a/WebFiori/Database/Schema/SchemaRunner.php
+++ b/WebFiori/Database/Schema/SchemaRunner.php
@@ -256,9 +256,19 @@ class SchemaRunner extends Database {
      * This table stores information about which migrations and seeders
      * have been applied, including timestamps and execution status.
      * Required for tracking database change history.
+     * 
+     * If the table already exists but is missing the 'status' column
+     * (upgrade from older version), the column will be added automatically.
      */
     public function createSchemaTable() {
         $this->createTables();
+
+        // Add status column if missing (upgrade path for existing installations)
+        try {
+            $this->table('schema_changes')->select(['status'])->limit(1)->execute();
+        } catch (\Throwable $e) {
+            $this->table('schema_changes')->addCol('status')->execute();
+        }
     }
 
     /**
@@ -525,6 +535,127 @@ class SchemaRunner extends Database {
         }
 
         return $rolled;
+    }
+
+    /**
+     * Skip a single change without executing it (baseline).
+     * 
+     * Records the change as 'skipped' in the schema_changes table so it
+     * won't be executed by future apply() calls.
+     * 
+     * @param DatabaseChange|string $change The change instance or class name.
+     * @return bool True if skipped successfully, false if already applied/skipped or not found.
+     */
+    public function skip(DatabaseChange|string $change): bool {
+        $instance = is_string($change) ? $this->findChangeByName($change) : $change;
+
+        if ($instance === null) {
+            return false;
+        }
+
+        if ($this->isApplied($instance->getName())) {
+            return false;
+        }
+
+        $batch = $this->getRepository()->getNextBatchNumber();
+        $this->getRepository()->recordSkipped($instance, $batch);
+
+        return true;
+    }
+
+    /**
+     * Skip all pending changes without executing them (baseline all).
+     * 
+     * @return array Array of skipped DatabaseChange instances.
+     */
+    public function skipAll(): array {
+        $skipped = [];
+        $batch = $this->getRepository()->getNextBatchNumber();
+
+        foreach ($this->dbChanges as $change) {
+            if ($this->isApplied($change->getName())) {
+                continue;
+            }
+
+            if (!$this->shouldRunInEnvironment($change)) {
+                continue;
+            }
+
+            $this->getRepository()->recordSkipped($change, $batch);
+            $skipped[] = $change;
+        }
+
+        return $skipped;
+    }
+
+    /**
+     * Skip the next N pending changes without executing them.
+     * 
+     * Changes are skipped in dependency order (same order apply() would use).
+     * 
+     * @param int $count Number of changes to skip.
+     * @return array Array of skipped DatabaseChange instances.
+     */
+    public function skipNext(int $count = 1): array {
+        $skipped = [];
+        $batch = $this->getRepository()->getNextBatchNumber();
+
+        foreach ($this->dbChanges as $change) {
+            if (count($skipped) >= $count) {
+                break;
+            }
+
+            if ($this->isApplied($change->getName())) {
+                continue;
+            }
+
+            if (!$this->shouldRunInEnvironment($change)) {
+                continue;
+            }
+
+            $this->getRepository()->recordSkipped($change, $batch);
+            $skipped[] = $change;
+        }
+
+        return $skipped;
+    }
+
+    /**
+     * Skip all pending changes up to and including the named one.
+     * 
+     * @param string $changeName The class name of the change to skip up to.
+     * @return array Array of skipped DatabaseChange instances.
+     */
+    public function skipUpTo(string $changeName): array {
+        $skipped = [];
+        $batch = $this->getRepository()->getNextBatchNumber();
+
+        foreach ($this->dbChanges as $change) {
+            if ($this->isApplied($change->getName())) {
+                if ($change->getName() === $changeName) {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (!$this->shouldRunInEnvironment($change)) {
+                if ($change->getName() === $changeName) {
+                    break;
+                }
+
+                continue;
+            }
+
+            $this->getRepository()->recordSkipped($change, $batch);
+            $skipped[] = $change;
+
+            if ($change->getName() === $changeName) {
+                break;
+            }
+        }
+
+        return $skipped;
     }
 
     private function areDependenciesSatisfied(DatabaseChange $change): bool {

--- a/tests/WebFiori/Tests/Database/Schema/SkipBaselineTest.php
+++ b/tests/WebFiori/Tests/Database/Schema/SkipBaselineTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace WebFiori\Tests\Database\Schema;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Database\Database;
+use WebFiori\Database\Schema\AbstractMigration;
+use WebFiori\Database\Schema\SchemaRunner;
+
+class SkipMigrationA extends AbstractMigration {
+    public function up(Database $db): void {
+        $db->table('schema_changes')->select(['id'])->limit(1)->execute();
+    }
+
+    public function down(Database $db): void {
+    }
+}
+
+class SkipMigrationB extends AbstractMigration {
+    public function up(Database $db): void {
+        $db->table('schema_changes')->select(['id'])->limit(1)->execute();
+    }
+
+    public function down(Database $db): void {
+    }
+}
+
+class SkipMigrationC extends AbstractMigration {
+    public function up(Database $db): void {
+        $db->table('schema_changes')->select(['id'])->limit(1)->execute();
+    }
+
+    public function down(Database $db): void {
+    }
+}
+
+class SkipBaselineTest extends TestCase {
+    private function getConnectionInfo(): ConnectionInfo {
+        return new ConnectionInfo('mysql', 'root', getenv('MYSQL_ROOT_PASSWORD') ?: '123456', 'testing_db', '127.0.0.1');
+    }
+
+    private function createRunner(): SchemaRunner {
+        $runner = new SchemaRunner($this->getConnectionInfo());
+        $runner->register(SkipMigrationA::class);
+        $runner->register(SkipMigrationB::class);
+        $runner->register(SkipMigrationC::class);
+        return $runner;
+    }
+
+    public function testSkipSingle() {
+        try {
+            $runner = $this->createRunner();
+            $runner->createSchemaTable();
+
+            $result = $runner->skip(SkipMigrationA::class);
+            $this->assertTrue($result);
+            $this->assertTrue($runner->isApplied(SkipMigrationA::class));
+
+            // apply() should not re-run it
+            $applyResult = $runner->apply();
+            $appliedNames = array_map(fn($c) => $c->getName(), $applyResult->getApplied());
+            $this->assertNotContains(SkipMigrationA::class, $appliedNames);
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('Database connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    public function testSkipAlreadyApplied() {
+        try {
+            $runner = $this->createRunner();
+            $runner->createSchemaTable();
+
+            // Apply first
+            $runner->apply();
+
+            // Try to skip — should return false
+            $result = $runner->skip(SkipMigrationA::class);
+            $this->assertFalse($result);
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('Database connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    public function testSkipAll() {
+        try {
+            $runner = $this->createRunner();
+            $runner->createSchemaTable();
+
+            $skipped = $runner->skipAll();
+            $this->assertCount(3, $skipped);
+
+            // All should be marked as applied now
+            $this->assertTrue($runner->isApplied(SkipMigrationA::class));
+            $this->assertTrue($runner->isApplied(SkipMigrationB::class));
+            $this->assertTrue($runner->isApplied(SkipMigrationC::class));
+
+            // Nothing pending
+            $pending = $runner->getPendingChanges();
+            $this->assertEmpty($pending);
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('Database connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    public function testSkipUpTo() {
+        try {
+            $runner = $this->createRunner();
+            $runner->createSchemaTable();
+
+            $skipped = $runner->skipUpTo(SkipMigrationB::class);
+            $this->assertCount(2, $skipped);
+
+            $this->assertTrue($runner->isApplied(SkipMigrationA::class));
+            $this->assertTrue($runner->isApplied(SkipMigrationB::class));
+            $this->assertFalse($runner->isApplied(SkipMigrationC::class));
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('Database connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    public function testSkipNext() {
+        try {
+            $runner = $this->createRunner();
+            $runner->createSchemaTable();
+
+            $skipped = $runner->skipNext(2);
+            $this->assertCount(2, $skipped);
+
+            $this->assertTrue($runner->isApplied(SkipMigrationA::class));
+            $this->assertTrue($runner->isApplied(SkipMigrationB::class));
+            $this->assertFalse($runner->isApplied(SkipMigrationC::class));
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('Database connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    public function testSkipRecordsStatusColumn() {
+        try {
+            $runner = $this->createRunner();
+            $runner->createSchemaTable();
+
+            $runner->skip(SkipMigrationA::class);
+
+            $records = $runner->getRepository()->getAllApplied();
+            $record = null;
+
+            foreach ($records as $r) {
+                if ($r['change_name'] === SkipMigrationA::class) {
+                    $record = $r;
+                    break;
+                }
+            }
+
+            $this->assertNotNull($record);
+            $this->assertEquals('skipped', $record['status']);
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('Database connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    public function testPendingExcludesSkipped() {
+        try {
+            $runner = $this->createRunner();
+            $runner->createSchemaTable();
+
+            $runner->skip(SkipMigrationA::class);
+
+            $pending = $runner->getPendingChanges();
+            $pendingNames = array_map(fn($p) => $p['change']->getName(), $pending);
+
+            $this->assertNotContains(SkipMigrationA::class, $pendingNames);
+            $this->assertContains(SkipMigrationB::class, $pendingNames);
+            $this->assertContains(SkipMigrationC::class, $pendingNames);
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('Database connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    public function testSkipNotFound() {
+        try {
+            $runner = $this->createRunner();
+            $runner->createSchemaTable();
+
+            $result = $runner->skip('NonExistent\\Migration');
+            $this->assertFalse($result);
+
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('Database connection failed: ' . $ex->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Add methods to record database changes as "skipped" without executing them, enabling onboarding of existing databases into the migration system.

## Motivation
When migrating an existing application to use WebFiori's migration system, all migrations need to be marked as "applied" without actually running them. This is the standard "baseline" pattern used by Flyway, Django, Laravel, and Liquibase. Fixes #136.

## Changes
- Added `status` column (`VARCHAR(20)`, default `applied`) to `SchemaMigrationsTable`
- `createSchemaTable()` auto-migrates existing tables to add the `status` column
- `SchemaChangeRepository::recordChange()` now explicitly sets `status = 'applied'`
- New `SchemaChangeRepository::recordSkipped()` method sets `status = 'skipped'`
- New `SchemaRunner` methods:
  - `skip($change)` — skip a single change by instance or class-string
  - `skipAll()` — skip all pending changes
  - `skipUpTo($name)` — skip up to and including a named change
  - `skipNext($count)` — skip the next N pending changes

## How to Test / Verify
```bash
vendor/bin/phpunit --filter "SkipBaselineTest" tests/WebFiori/Tests/Database/Schema/SkipBaselineTest.php
```

8 test cases covering: single skip, skip already-applied, skipAll, skipUpTo, skipNext, status column verification, pending exclusion, and not-found handling.

## Breaking Changes and Migration Steps
None. The `status` column is added automatically with a default of `applied`, so existing records are unaffected.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #136