### PR TITLE
Feature: add addTableFromClass() and addTablesFromClasses()

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ $database->createBlueprint('users')->addColumns([
 $database->table('users')->createTable()->execute();
 ```
 
+You can also register tables from classes that use `#[Table]`/`#[Column]` attributes or extend `Table`:
+
+```php
+// Single class
+$database->addTableFromClass(Users::class);
+
+// Multiple classes at once
+$database->addTablesFromClasses([Users::class, Posts::class, Comments::class]);
+```
+
+This works with both attribute-based classes and `Table` subclasses (`MySQLTable`/`MSSQLTable`). If the class engine differs from the connection, it is converted automatically.
+
 ### Repository Pattern
 
 The `AbstractRepository` class provides a clean way to handle data access with separation between entities and database logic.

--- a/WebFiori/Database/Database.php
+++ b/WebFiori/Database/Database.php
@@ -12,6 +12,7 @@
 namespace WebFiori\Database;
 
 use Exception;
+use WebFiori\Database\Attributes\AttributeTableBuilder;
 use WebFiori\Database\Factory\TableFactory;
 use WebFiori\Database\MsSql\MSSQLQuery;
 use WebFiori\Database\MsSql\MSSQLTable;
@@ -174,6 +175,61 @@ class Database {
     }
 
     /**
+     * Registers a table from a class-string.
+     * 
+     * The class can either be a subclass of Table (e.g. MySQLTable/MSSQLTable)
+     * or a class annotated with #[Table] and #[Column] attributes.
+     * 
+     * If the class is a Table subclass with a different engine than the current
+     * connection, it will be converted automatically.
+     * 
+     * @param string $className Fully qualified class name.
+     * 
+     * @return Table The registered table instance.
+     * 
+     * @throws DatabaseException If the class cannot be instantiated or lacks
+     * required attributes.
+     */
+    public function addTableFromClass(string $className): Table {
+        $connInfo = $this->getConnectionInfo();
+        $dbType = $connInfo !== null ? $connInfo->getDatabaseType() : 'mysql';
+
+        if (is_subclass_of($className, Table::class)) {
+            try {
+                $table = new $className();
+            } catch (\Throwable $e) {
+                throw new DatabaseException('Failed to instantiate table class "'.$className.'": '.$e->getMessage());
+            }
+            $table = TableFactory::map($dbType, $table);
+        } else {
+            $table = AttributeTableBuilder::build($className, $dbType);
+        }
+
+        $this->addTable($table);
+
+        return $table;
+    }
+
+    /**
+     * Registers multiple tables from an array of class-strings.
+     * 
+     * @param string[] $classNames Array of fully qualified class names.
+     * 
+     * @return Table[] Array of registered table instances.
+     * 
+     * @throws DatabaseException If any class cannot be registered.
+     */
+    public function addTablesFromClasses(array $classNames): array {
+        $tables = [];
+
+        foreach ($classNames as $className) {
+            $tables[] = $this->addTableFromClass($className);
+        }
+
+        return $tables;
+    }
+
+    /**
      * Build a 'where' expression.
      *
      * This method can be used to append an 'and' condition to an already existing
@@ -226,6 +282,19 @@ class Database {
     public function clearPerformanceMetrics(): void {
         if ($this->performanceMonitor !== null) {
             $this->performanceMonitor->clearMetrics();
+        }
+    }
+    /**
+     * Release the current connection back to the pool.
+     * 
+     * After calling this method, the connection is returned to the pool
+     * for reuse by other Database instances. The next call to getConnection()
+     * will acquire a new connection from the pool.
+     */
+    public function close(): void {
+        if ($this->connection !== null) {
+            ConnectionPool::getInstance()->release($this->connection);
+            $this->connection = null;
         }
     }
     /**
@@ -825,19 +894,6 @@ class Database {
      */
     public function setConnection(Connection $con) {
         $this->connection = $con;
-    }
-    /**
-     * Release the current connection back to the pool.
-     * 
-     * After calling this method, the connection is returned to the pool
-     * for reuse by other Database instances. The next call to getConnection()
-     * will acquire a new connection from the pool.
-     */
-    public function close(): void {
-        if ($this->connection !== null) {
-            ConnectionPool::getInstance()->release($this->connection);
-            $this->connection = null;
-        }
     }
     /**
      * Sets database connection information.

--- a/WebFiori/Database/Factory/TableFactory.php
+++ b/WebFiori/Database/Factory/TableFactory.php
@@ -11,6 +11,7 @@
  */
 namespace WebFiori\Database\Factory;
 
+use WebFiori\Database\Column;
 use WebFiori\Database\ConnectionInfo;
 use WebFiori\Database\DatabaseException;
 use WebFiori\Database\MsSql\MSSQLTable;

--- a/examples/10-attribute-based-tables/README.md
+++ b/examples/10-attribute-based-tables/README.md
@@ -8,6 +8,7 @@ This example demonstrates how to define database tables using PHP 8 attributes.
 - Using `#[Column]` attribute for column properties
 - Using `#[ForeignKey]` attribute for relationships
 - Building tables with `AttributeTableBuilder`
+- Registering tables with `addTableFromClass()` and `addTablesFromClasses()`
 
 ## Files
 

--- a/examples/10-attribute-based-tables/example.php
+++ b/examples/10-attribute-based-tables/example.php
@@ -17,7 +17,7 @@ try {
     $database = new Database($connection);
 
     echo SEP;
-    echo "1. Building Tables from Attributes:\n";
+    echo "1. Building Tables from Attributes (verbose approach):\n";
 
     $authorsTable = AttributeTableBuilder::build(Author::class, 'mysql');
     $articlesTable = AttributeTableBuilder::build(Article::class, 'mysql');
@@ -29,12 +29,27 @@ try {
     echo "     Columns: ".implode(', ', array_keys($articlesTable->getCols()))."\n\n";
 
     echo SEP;
-    echo "2. Generated SQL:\n";
+    echo "2. Shorthand: Register tables with addTableFromClass():\n";
+
+    // Instead of the 3-step process above, you can do it in one call:
+    $database2 = new Database($connection);
+    $authorsTable2 = $database2->addTableFromClass(Author::class);
+    $articlesTable2 = $database2->addTableFromClass(Article::class);
+    echo "   ✓ Authors table registered: ".$authorsTable2->getNormalName()."\n";
+    echo "   ✓ Articles table registered: ".$articlesTable2->getNormalName()."\n";
+
+    // Or register multiple at once:
+    $database3 = new Database($connection);
+    $tables = $database3->addTablesFromClasses([Author::class, Article::class]);
+    echo "   ✓ Bulk registered ".count($tables)." tables\n\n";
+
+    echo SEP;
+    echo "3. Generated SQL:\n";
     echo "   Authors table:\n   ".$authorsTable->toSQL()."\n\n";
     echo "   Articles table:\n   ".$articlesTable->toSQL()."\n\n";
 
     echo SEP;
-    echo "3. Creating Tables:\n";
+    echo "4. Creating Tables:\n";
 
     $database->addTable($authorsTable);
     $database->addTable($articlesTable);

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,6 +108,7 @@ You can modify the connection parameters in each example as needed.
 - Using PHP 8 attributes: `#[Table]`, `#[Column]`, `#[ForeignKey]`
 - Building tables with `AttributeTableBuilder::build()`
 - Defining entities with attribute-based schema
+- Registering tables with `addTableFromClass()` and `addTablesFromClasses()`
 
 ### 11-repository-pattern
 - Extending `AbstractRepository` for CRUD operations

--- a/tests/WebFiori/Tests/Database/Common/AddTableFromClassTest.php
+++ b/tests/WebFiori/Tests/Database/Common/AddTableFromClassTest.php
@@ -1,0 +1,295 @@
+<?php
+namespace WebFiori\Tests\Database\Common;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Database\Attributes\Column;
+use WebFiori\Database\Attributes\InvalidAttributeException;
+use WebFiori\Database\Attributes\Table;
+use WebFiori\Database\ColOption;
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Database\Database;
+use WebFiori\Database\DatabaseException;
+use WebFiori\Database\DataType;
+use WebFiori\Database\MsSql\MSSQLTable;
+use WebFiori\Database\MySql\MySQLTable;
+
+// --- Test Fixtures ---
+
+#[Table(name: 'attr_users')]
+class AttrUserFixture {
+    #[Column(type: DataType::VARCHAR, size: 150)]
+    public string $email;
+    #[Column(type: DataType::INT, primary: true, autoIncrement: true)]
+    public int $id;
+
+    #[Column(type: DataType::VARCHAR, size: 100)]
+    public string $name;
+}
+
+#[Table(name: 'attr_posts')]
+class AttrPostFixture {
+    #[Column(type: DataType::INT, primary: true, autoIncrement: true)]
+    public int $id;
+
+    #[Column(type: DataType::VARCHAR, size: 200)]
+    public string $title;
+}
+
+#[Table(name: 'attr_empty')]
+class AttrEmptyFixture {
+}
+
+class PlainClassFixture {
+    public string $name;
+}
+
+class MySQLSubclassFixture extends MySQLTable {
+    public function __construct() {
+        parent::__construct('mysql_sub_table');
+        $this->addColumns([
+            'id' => [
+                ColOption::TYPE => DataType::INT,
+                ColOption::PRIMARY => true,
+                ColOption::AUTO_INCREMENT => true
+            ],
+            'title' => [
+                ColOption::TYPE => DataType::VARCHAR,
+                ColOption::SIZE => 100
+            ]
+        ]);
+    }
+}
+
+class MSSQLSubclassFixture extends MSSQLTable {
+    public function __construct() {
+        parent::__construct('mssql_sub_table');
+        $this->addColumns([
+            'id' => [
+                ColOption::TYPE => DataType::INT,
+                ColOption::PRIMARY => true,
+                ColOption::IDENTITY => true
+            ],
+            'title' => [
+                ColOption::TYPE => DataType::VARCHAR,
+                ColOption::SIZE => 100
+            ]
+        ]);
+    }
+}
+
+class RequiredArgTableFixture extends MySQLTable {
+    public function __construct(string $requiredArg) {
+        parent::__construct($requiredArg);
+    }
+}
+
+#[Table(name: 'attr_with_parent')]
+class AttrAndSubclassFixture extends MySQLTable {
+    #[Column(type: DataType::INT, primary: true)]
+    public int $id;
+
+    public function __construct() {
+        parent::__construct('subclass_wins');
+        $this->addColumns([
+            'id' => [
+                ColOption::TYPE => DataType::INT,
+                ColOption::PRIMARY => true,
+            ],
+            'name' => [
+                ColOption::TYPE => DataType::VARCHAR,
+                ColOption::SIZE => 50
+            ]
+        ]);
+    }
+}
+
+// --- Tests ---
+
+class AddTableFromClassTest extends TestCase {
+    // Test 12: Abstract class throws
+    public function testAbstractClassThrows() {
+        $this->expectException(\Throwable::class);
+        $db = $this->createMySQLDatabase();
+        $db->addTableFromClass(\WebFiori\Database\Table::class);
+    }
+
+    // Test 1: Attribute-based class registers correctly
+    public function testAddAttributeBasedClass() {
+        $db = $this->createMySQLDatabase();
+        $table = $db->addTableFromClass(AttrUserFixture::class);
+
+        $this->assertNotNull($table);
+        $this->assertEquals('attr_users', $table->getNormalName());
+        $this->assertTrue($db->hasTable('attr_users'));
+    }
+
+    // Test 3: Bulk registration
+    public function testAddTablesFromClasses() {
+        $db = $this->createMySQLDatabase();
+        $tables = $db->addTablesFromClasses([
+            AttrUserFixture::class,
+            AttrPostFixture::class,
+            MySQLSubclassFixture::class
+        ]);
+
+        $this->assertCount(3, $tables);
+        $this->assertTrue($db->hasTable('attr_users'));
+        $this->assertTrue($db->hasTable('attr_posts'));
+        $this->assertTrue($db->hasTable('mysql_sub_table'));
+    }
+
+    // Test 2: Table subclass registers correctly
+    public function testAddTableSubclass() {
+        $db = $this->createMySQLDatabase();
+        $table = $db->addTableFromClass(MySQLSubclassFixture::class);
+
+        $this->assertNotNull($table);
+        $this->assertEquals('mysql_sub_table', $table->getNormalName());
+        $this->assertTrue($db->hasTable('mysql_sub_table'));
+    }
+
+    // Test 7: Attribute class with no columns
+    public function testAttributeClassNoColumns() {
+        $db = $this->createMySQLDatabase();
+        $table = $db->addTableFromClass(AttrEmptyFixture::class);
+
+        $this->assertNotNull($table);
+        $this->assertEquals('attr_empty', $table->getNormalName());
+        $this->assertEquals(0, $table->getColsCount());
+    }
+
+    // Test 10: DB type propagation - attribute class on MSSQL
+    public function testAttributeClassOnMSSQL() {
+        $db = $this->createMSSQLDatabase();
+        $table = $db->addTableFromClass(AttrUserFixture::class);
+
+        $this->assertInstanceOf(MSSQLTable::class, $table);
+    }
+
+    // Test 18: Partial failure in bulk - fail-fast
+    public function testBulkPartialFailure() {
+        $this->expectException(InvalidAttributeException::class);
+        $db = $this->createMySQLDatabase();
+        $db->addTablesFromClasses([
+            AttrUserFixture::class,
+            PlainClassFixture::class, // This will fail
+            AttrPostFixture::class
+        ]);
+    }
+
+    // Verify first table was registered before failure
+    public function testBulkPartialFailureFirstRegistered() {
+        $db = $this->createMySQLDatabase();
+
+        try {
+            $db->addTablesFromClasses([
+                AttrUserFixture::class,
+                PlainClassFixture::class,
+                AttrPostFixture::class
+            ]);
+        } catch (\Throwable $e) {
+            // Expected
+        }
+
+        $this->assertTrue($db->hasTable('attr_users'));
+        $this->assertFalse($db->hasTable('attr_posts'));
+    }
+
+    // Test 8: Duplicate registration returns false on second addTable
+    public function testDuplicateRegistration() {
+        $db = $this->createMySQLDatabase();
+        $table1 = $db->addTableFromClass(AttrUserFixture::class);
+        $table2 = $db->addTableFromClass(AttrUserFixture::class);
+
+        // addTable returns false for duplicates, but addTableFromClass still returns the built table
+        // The table should only exist once
+        $this->assertNotNull($table1);
+        $this->assertNotNull($table2);
+        $this->assertTrue($db->hasTable('attr_users'));
+    }
+
+    // Test 15: MSSQLTable subclass on MySQL connection gets converted
+    public function testMSSQLSubclassOnMySQLConnection() {
+        $db = $this->createMySQLDatabase();
+        $table = $db->addTableFromClass(MSSQLSubclassFixture::class);
+
+        $this->assertInstanceOf(MySQLTable::class, $table);
+        $this->assertEquals('mssql_sub_table', $table->getNormalName());
+        $this->assertTrue($table->hasColumn('id'));
+        $this->assertTrue($table->hasColumn('title'));
+    }
+
+    // Test 14: MySQLTable subclass on MSSQL connection gets converted
+    public function testMySQLSubclassOnMSSQLConnection() {
+        $db = $this->createMSSQLDatabase();
+        $table = $db->addTableFromClass(MySQLSubclassFixture::class);
+
+        $this->assertInstanceOf(MSSQLTable::class, $table);
+        $this->assertEquals('mysql_sub_table', $table->getNormalName());
+        $this->assertTrue($table->hasColumn('id'));
+        $this->assertTrue($table->hasColumn('title'));
+    }
+
+    // Test 6: Non-existent class throws
+    public function testNonExistentClassThrows() {
+        $this->expectException(\Throwable::class);
+        $db = $this->createMySQLDatabase();
+        $db->addTableFromClass('App\\NonExistent\\Ghost');
+    }
+
+    // Test 5: Plain class without #[Table] throws
+    public function testPlainClassThrows() {
+        $this->expectException(InvalidAttributeException::class);
+        $db = $this->createMySQLDatabase();
+        $db->addTableFromClass(PlainClassFixture::class);
+    }
+
+    // Test 4: Return value has correct columns
+    public function testReturnValueCorrectness() {
+        $db = $this->createMySQLDatabase();
+        $table = $db->addTableFromClass(AttrUserFixture::class);
+
+        $this->assertEquals(3, $table->getColsCount());
+        $this->assertTrue($table->hasColumn('id'));
+        $this->assertTrue($table->hasColumn('name'));
+        $this->assertTrue($table->hasColumn('email'));
+    }
+
+    // Test 16: Same engine - no conversion needed
+    public function testSameEngineNoConversion() {
+        $db = $this->createMySQLDatabase();
+        $table = $db->addTableFromClass(MySQLSubclassFixture::class);
+
+        $this->assertInstanceOf(MySQLTable::class, $table);
+        $this->assertEquals('mysql_sub_table', $table->getNormalName());
+    }
+
+    // Test 17: Class extends Table AND has #[Table] attribute - subclass wins
+    public function testSubclassWinsOverAttributes() {
+        $db = $this->createMySQLDatabase();
+        $table = $db->addTableFromClass(AttrAndSubclassFixture::class);
+
+        // Subclass path is taken, so table name comes from constructor
+        $this->assertEquals('subclass_wins', $table->getNormalName());
+        // Should have columns defined in constructor, not from attributes
+        $this->assertTrue($table->hasColumn('name'));
+    }
+
+    // Test 13: Table subclass with required constructor args throws
+    public function testSubclassWithRequiredArgsThrows() {
+        $this->expectException(DatabaseException::class);
+        $db = $this->createMySQLDatabase();
+        $db->addTableFromClass(RequiredArgTableFixture::class);
+    }
+
+    private function createMSSQLDatabase(): Database {
+        $connInfo = new ConnectionInfo('mssql', 'sa', 'password', 'testing_db', '127.0.0.1');
+
+        return new Database($connInfo);
+    }
+    private function createMySQLDatabase(): Database {
+        $connInfo = new ConnectionInfo('mysql', 'root', '123456', 'testing_db', '127.0.0.1');
+
+        return new Database($connInfo);
+    }
+}


### PR DESCRIPTION
# Summary
Add convenience methods to register tables from a class-string, supporting both attribute-based classes and Table subclasses with automatic engine conversion.

## Motivation
Registering attribute-based tables required 3 verbose steps (instantiate builder, get table, add table). This reduces it to a single call. Fixes #138.

## Changes
- Added `Database::addTableFromClass(string $className): Table`
- Added `Database::addTablesFromClasses(array $classNames): array`
- Fixed missing `Column` import in `TableFactory` that broke cross-engine `map()` conversion
- Added 17 unit tests covering happy paths, error cases, and engine conversion

## How to Test / Verify
Unit tests via PHPUnit:
```
php vendor/bin/phpunit -c tests/phpunit10.xml --testsuite "Common Tests" --filter "AddTableFromClass"
```
All 17 tests pass. Full Common and MySQL suites also pass with no regressions.

## Breaking Changes and Migration Steps
None

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #138