### PR TITLE
fix: reset stale query bindings to prevent type conversion errors

### DIFF
--- a/WebFiori/Database/AbstractQuery.php
+++ b/WebFiori/Database/AbstractQuery.php
@@ -31,6 +31,10 @@ abstract class AbstractQuery {
      */
     private $associatedTbl;
     /**
+     * @var array Parameter bindings for prepared statements.
+     */
+    private $bindings;
+    /**
      * 
      * @var InsertHelper
      */
@@ -81,10 +85,6 @@ abstract class AbstractQuery {
      * 
      */
     private $query;
-    /**
-     * @var array Parameter bindings for prepared statements.
-     */
-    private $bindings;
     /**
      *
      * @var Database 

--- a/WebFiori/Database/Database.php
+++ b/WebFiori/Database/Database.php
@@ -198,7 +198,7 @@ class Database {
             try {
                 $table = new $className();
             } catch (\Throwable $e) {
-                throw new DatabaseException('Failed to instantiate table class "'.$className.'": '.$e->getMessage());
+                throw new DatabaseException('Failed to instantiate table class "'.$className.'": '.$e->getCode().' - '.$e->getMessage()." at ".$e->getFile().':'.$e->getLine()."\nStack Trace: ".$e->getTraceAsString());
             }
             $table = TableFactory::map($dbType, $table);
         } else {
@@ -752,7 +752,10 @@ class Database {
         } catch (DatabaseException $ex) {
             $this->lastErr = [
                 'code' => $ex->getCode(),
-                'message' => $ex->getMessage()
+                'message' => $ex->getMessage(),
+                'file' => $ex->getFile(),
+                'line' => $ex->getLine(),
+                'trace' => $ex->getTraceAsString()
             ];
 
             return false;

--- a/WebFiori/Database/MsSql/MSSQLQuery.php
+++ b/WebFiori/Database/MsSql/MSSQLQuery.php
@@ -238,6 +238,7 @@ class MSSQLQuery extends AbstractQuery {
      * 
      */
     public function update(array $newColsVals) {
+        $this->resetBinding();
         $updateArr = [];
         $colsWithVals = [];
         $tblName = $this->getTable()->getName();

--- a/WebFiori/Database/MySql/MySQLColumn.php
+++ b/WebFiori/Database/MySql/MySQLColumn.php
@@ -370,7 +370,7 @@ class MySQLColumn extends Column {
         try {
             parent::setDatatype($type);
         } catch (DatabaseException $ex) {
-            throw new DatabaseException($ex->getMessage());
+            throw new DatabaseException($ex->getMessage(), $ex->getCode());
         }
 
         $s_type = $this->getDatatype();

--- a/WebFiori/Database/MySql/MySQLConnection.php
+++ b/WebFiori/Database/MySql/MySQLConnection.php
@@ -66,33 +66,6 @@ class MySQLConnection extends Connection {
         $this->close();
     }
 
-    /**
-     * Close the MySQL connection and release resources.
-     */
-    public function close(): void {
-        if ($this->link !== null) {
-            @mysqli_close($this->link);
-            $this->link = null;
-        }
-    }
-
-    /**
-     * Check if the MySQL connection is still alive.
-     * 
-     * @return bool True if the connection is active.
-     */
-    public function isAlive(): bool {
-        if ($this->link === null) {
-            return false;
-        }
-
-        try {
-            return @$this->link->query('SELECT 1') !== false;
-        } catch (\Exception $e) {
-            return false;
-        }
-    }
-
     public function beginTransaction(?string $name = null) {
         //The null check is for php<8
         $message = 'Unable to start transaction.';
@@ -105,6 +78,16 @@ class MySQLConnection extends Connection {
             if (!$this->link->begin_transaction()) {
                 throw new DatabaseException($message);
             }
+        }
+    }
+
+    /**
+     * Close the MySQL connection and release resources.
+     */
+    public function close(): void {
+        if ($this->link !== null) {
+            @mysqli_close($this->link);
+            $this->link = null;
         }
     }
 
@@ -185,6 +168,23 @@ class MySQLConnection extends Connection {
      */
     public function getMysqliLink() {
         return $this->link;
+    }
+
+    /**
+     * Check if the MySQL connection is still alive.
+     * 
+     * @return bool True if the connection is active.
+     */
+    public function isAlive(): bool {
+        if ($this->link === null) {
+            return false;
+        }
+
+        try {
+            return @$this->link->query('SELECT 1') !== false;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     public function rollBack(?string $name = null) {

--- a/WebFiori/Database/MySql/MySQLQuery.php
+++ b/WebFiori/Database/MySql/MySQLQuery.php
@@ -401,6 +401,7 @@ class MySQLQuery extends AbstractQuery {
      * 
      */
     public function update(array $newColsVals) {
+        $this->resetBinding();
         $updateArr = [];
         $colsWithVals = [];
         $tblName = $this->getTable()->getName();

--- a/WebFiori/Database/Schema/SchemaChangeRepository.php
+++ b/WebFiori/Database/Schema/SchemaChangeRepository.php
@@ -53,6 +53,7 @@ class SchemaChangeRepository extends AbstractRepository {
      * @return int Number of applied changes
      */
     public function count(array $conditions = []): int {
+        $this->getDatabase()->resetBinding();
         $query = $this->getDatabase()->table($this->getTableName())->select();
 
         foreach ($conditions as $col => $val) {

--- a/WebFiori/Database/Schema/SchemaRunner.php
+++ b/WebFiori/Database/Schema/SchemaRunner.php
@@ -391,7 +391,7 @@ class SchemaRunner extends Database {
                     $info['queries'] = $this->getCapturedQueries();
                 } catch (\Throwable $ex) {
                     // Capture failed, queries may be partial
-                    $info['queries'] = array_merge($this->getCapturedQueries(), ['Error: '.$ex->getMessage()]);
+                    $info['queries'] = array_merge($this->getCapturedQueries(), ['Error: '.$ex->getCode().' - '.$ex->getMessage()." at ".$ex->getFile().":".$ex->getLine()."\nStack Trace:".$ex->getTraceAsString()]);
                 }
                 $this->setDryRun(false);
             }

--- a/WebFiori/Database/Schema/SchemaRunner.php
+++ b/WebFiori/Database/Schema/SchemaRunner.php
@@ -174,6 +174,7 @@ class SchemaRunner extends Database {
                     $processed[$name] = true;
                     $appliedInPass = true;
                 } catch (\Throwable $ex) {
+                    $this->resetBinding();
                     $result->addFailed($change, $ex);
                     $processed[$name] = true;
 
@@ -230,6 +231,8 @@ class SchemaRunner extends Database {
                     $change->setBatch($batch);
                     $this->getRepository()->recordChange($change);
                 } catch (\Throwable $ex) {
+                    $this->resetBinding();
+
                     foreach ($this->onErrCallbacks as $callback) {
                         call_user_func_array($callback, [$ex, $change, $this]);
                     }
@@ -238,6 +241,8 @@ class SchemaRunner extends Database {
                 return $change;
             }
         } catch (\Throwable $ex) {
+            $this->resetBinding();
+
             foreach ($this->onErrCallbacks as $callback) {
                 call_user_func_array($callback, [$ex, $change, $this]);
             }

--- a/tests/WebFiori/Tests/Database/Common/StaleBindingsTest.php
+++ b/tests/WebFiori/Tests/Database/Common/StaleBindingsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace WebFiori\Tests\Database\Common;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Database\ColOption;
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Database\ConnectionPool;
+use WebFiori\Database\Database;
+use WebFiori\Database\DataType;
+
+/**
+ * Tests that stale bindings from abandoned queries do not corrupt subsequent
+ * update queries or repository operations.
+ */
+class StaleBindingsTest extends TestCase {
+    private Database $db;
+
+    protected function setUp(): void {
+        $conn = new ConnectionInfo('sqlite', '', '', ':memory:');
+        $this->db = new Database($conn);
+        $this->db->createBlueprint('users')->addColumns([
+            'id' => [ColOption::TYPE => DataType::INT, ColOption::PRIMARY => true, ColOption::AUTO_INCREMENT => true],
+            'name' => [ColOption::TYPE => DataType::VARCHAR, ColOption::SIZE => 100],
+            'age' => [ColOption::TYPE => DataType::INT],
+        ]);
+        $this->db->table('users')->createTable()->execute();
+        $this->db->table('users')->insert(['name' => 'Alice', 'age' => 30])->execute();
+        $this->db->table('users')->insert(['name' => 'Bob', 'age' => 25])->execute();
+    }
+
+    protected function tearDown(): void {
+        $this->db->close();
+        ConnectionPool::reset();
+    }
+
+    public function testUpdateResetsBindingsFromAbandonedQuery() {
+        // Abandon a select with stale binding
+        $this->db->table('users')->select()->where('age', 999);
+
+        // update() resets bindings before adding its own
+        $this->db->table('users')->update(['name' => 'Alice Updated'])->where('id', 1)->execute();
+
+        $result = $this->db->table('users')->select()->where('id', 1)->execute();
+        $this->assertEquals('Alice Updated', $result->getRows()[0]['name']);
+    }
+
+    public function testUpdateAfterExceptionDoesNotCorrupt() {
+        try {
+            $this->db->table('users')->select()->where('age', 100);
+            throw new \RuntimeException('crash');
+        } catch (\RuntimeException $e) {
+            // stale binding 100
+        }
+
+        // update() should work correctly despite stale bindings
+        $this->db->table('users')->update(['name' => 'Bob Updated'])->where('id', 2)->execute();
+
+        $result = $this->db->table('users')->select()->where('id', 2)->execute();
+        $this->assertEquals('Bob Updated', $result->getRows()[0]['name']);
+    }
+
+    public function testDatabaseSelectClearsBindings() {
+        // Abandon query via table()->select() chain
+        $this->db->table('users')->select()->where('age', 999);
+
+        // Database::select() calls clear() which resets bindings
+        $result = $this->db->select(['*'])->where('name', 'Alice')->execute();
+        $this->assertEquals(1, $result->getRowsCount());
+    }
+
+    public function testDatabaseDeleteClearsBindings() {
+        // Abandon query
+        $this->db->table('users')->select()->where('age', 999);
+
+        // Database::delete() calls clear() which resets bindings
+        $this->db->table('users');
+        $this->db->delete()->where('name', 'Bob')->execute();
+
+        $result = $this->db->table('users')->select()->execute();
+        $this->assertEquals(1, $result->getRowsCount());
+    }
+}

--- a/tests/WebFiori/Tests/Database/Schema/SchemaRunnerApplyMultipleTest.php
+++ b/tests/WebFiori/Tests/Database/Schema/SchemaRunnerApplyMultipleTest.php
@@ -1,0 +1,531 @@
+<?php
+
+namespace WebFiori\Tests\Database\Schema;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Database\ConnectionPool;
+use WebFiori\Database\Database;
+use WebFiori\Database\Schema\AbstractMigration;
+use WebFiori\Database\Schema\AbstractSeeder;
+use WebFiori\Database\Schema\SchemaRunner;
+
+// --- Test fixtures ---
+
+class SimpleMigrationA extends AbstractMigration {
+    public function up(Database $db): void {
+    }
+
+    public function down(Database $db): void {
+    }
+}
+
+class SimpleMigrationB extends AbstractMigration {
+    public function up(Database $db): void {
+    }
+
+    public function down(Database $db): void {
+    }
+}
+
+class SimpleMigrationC extends AbstractMigration {
+    public function up(Database $db): void {
+    }
+
+    public function down(Database $db): void {
+    }
+}
+
+class SimpleSeederA extends AbstractSeeder {
+    public function run(Database $db): void {
+    }
+}
+
+/**
+ * Migration that builds a query with an int binding then throws,
+ * leaving stale bindings on the query generator.
+ */
+class FailingMigrationWithDirtyBindings extends AbstractMigration {
+    public function up(Database $db): void {
+        // This adds an int binding (100) to the query generator
+        $db->table('schema_changes')->select()->where('batch', 100);
+        // Throw before execute() — bindings remain dirty
+        throw new \RuntimeException('Simulated failure');
+    }
+
+    public function down(Database $db): void {
+    }
+
+    public function useTransaction(Database $db): bool {
+        return false;
+    }
+}
+
+/**
+ * Tests that SchemaRunner::apply() can be called multiple times without failing.
+ *
+ * Specifically targets the SchemaChangeRepository::count(array $cond) method
+ * which is called by SchemaRunner::isApplied() on each apply() invocation.
+ */
+class SchemaRunnerApplyMultipleTest extends TestCase {
+    protected function tearDown(): void {
+        ConnectionPool::reset();
+        parent::tearDown();
+    }
+
+    private function createSqliteRunner(): SchemaRunner {
+        $conn = new ConnectionInfo('sqlite', '', '', ':memory:');
+        $runner = new SchemaRunner($conn);
+        $runner->createSchemaTable();
+
+        return $runner;
+    }
+
+    /**
+     * Test calling apply() twice - second call should skip already-applied changes.
+     */
+    public function testApplyTwiceNoFailure() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+
+        $result1 = $runner->apply();
+        $this->assertCount(1, $result1->getApplied());
+        $this->assertCount(0, $result1->getFailed());
+
+        $result2 = $runner->apply();
+        $this->assertCount(0, $result2->getApplied());
+        $this->assertCount(1, $result2->getSkipped());
+        $this->assertCount(0, $result2->getFailed());
+    }
+
+    /**
+     * Test calling apply() three times in succession.
+     */
+    public function testApplyThreeTimesNoFailure() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+        $runner->register(SimpleMigrationB::class);
+
+        $result1 = $runner->apply();
+        $this->assertCount(2, $result1->getApplied());
+
+        $result2 = $runner->apply();
+        $this->assertCount(0, $result2->getApplied());
+        $this->assertCount(2, $result2->getSkipped());
+
+        $result3 = $runner->apply();
+        $this->assertCount(0, $result3->getApplied());
+        $this->assertCount(2, $result3->getSkipped());
+    }
+
+    /**
+     * Test calling apply() when new migrations are registered between calls.
+     */
+    public function testApplyWithNewMigrationsBetweenCalls() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+
+        $result1 = $runner->apply();
+        $this->assertCount(1, $result1->getApplied());
+
+        $runner->register(SimpleMigrationB::class);
+        $runner->register(SimpleMigrationC::class);
+
+        $result2 = $runner->apply();
+        $this->assertCount(2, $result2->getApplied());
+        $this->assertCount(1, $result2->getSkipped());
+    }
+
+    /**
+     * Test isApplied() (which calls count with conditions) after multiple apply() calls.
+     */
+    public function testIsAppliedAfterMultipleApplyCalls() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+        $runner->register(SimpleMigrationB::class);
+
+        $this->assertFalse($runner->isApplied(SimpleMigrationA::class));
+        $this->assertFalse($runner->isApplied(SimpleMigrationB::class));
+
+        $runner->apply();
+
+        $this->assertTrue($runner->isApplied(SimpleMigrationA::class));
+        $this->assertTrue($runner->isApplied(SimpleMigrationB::class));
+
+        $runner->apply();
+
+        $this->assertTrue($runner->isApplied(SimpleMigrationA::class));
+        $this->assertTrue($runner->isApplied(SimpleMigrationB::class));
+
+        $runner->apply();
+
+        $this->assertTrue($runner->isApplied(SimpleMigrationA::class));
+        $this->assertTrue($runner->isApplied(SimpleMigrationB::class));
+    }
+
+    /**
+     * Test repository count() with conditions called many times in a loop.
+     */
+    public function testCountCalledRepeatedlyInLoop() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+        $runner->register(SimpleMigrationB::class);
+        $runner->register(SimpleMigrationC::class);
+        $runner->register(SimpleSeederA::class);
+
+        $runner->apply();
+
+        $repo = $runner->getRepository();
+
+        for ($i = 0; $i < 20; $i++) {
+            $countA = $repo->count(['change_name' => SimpleMigrationA::class]);
+            $this->assertEquals(1, $countA, "count() failed on iteration $i for SimpleMigrationA");
+
+            $countB = $repo->count(['change_name' => SimpleMigrationB::class]);
+            $this->assertEquals(1, $countB, "count() failed on iteration $i for SimpleMigrationB");
+
+            $countC = $repo->count(['change_name' => SimpleMigrationC::class]);
+            $this->assertEquals(1, $countC, "count() failed on iteration $i for SimpleMigrationC");
+
+            $countNonExistent = $repo->count(['change_name' => 'NonExistent\\Class']);
+            $this->assertEquals(0, $countNonExistent, "count() failed on iteration $i for non-existent");
+        }
+    }
+
+    /**
+     * Test apply() called 5 times in rapid succession.
+     */
+    public function testApplyFiveTimesRapidly() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+        $runner->register(SimpleMigrationB::class);
+        $runner->register(SimpleMigrationC::class);
+
+        for ($i = 0; $i < 5; $i++) {
+            $result = $runner->apply();
+            $this->assertCount(0, $result->getFailed(), "apply() failed on call #" . ($i + 1));
+
+            if ($i === 0) {
+                $this->assertCount(3, $result->getApplied());
+            } else {
+                $this->assertCount(0, $result->getApplied());
+                $this->assertCount(3, $result->getSkipped());
+            }
+        }
+    }
+
+    /**
+     * Test apply() after rollback and re-apply.
+     */
+    public function testApplyRollbackReapply() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+        $runner->register(SimpleMigrationB::class);
+
+        $result1 = $runner->apply();
+        $this->assertCount(2, $result1->getApplied());
+
+        $runner->rollbackUpTo(null);
+
+        $this->assertFalse($runner->isApplied(SimpleMigrationA::class));
+        $this->assertFalse($runner->isApplied(SimpleMigrationB::class));
+
+        $result2 = $runner->apply();
+        $this->assertCount(2, $result2->getApplied());
+        $this->assertCount(0, $result2->getFailed());
+
+        $result3 = $runner->apply();
+        $this->assertCount(0, $result3->getApplied());
+        $this->assertCount(2, $result3->getSkipped());
+    }
+
+    /**
+     * Test count() with and without conditions interleaved.
+     */
+    public function testCountWithAndWithoutConditions() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+        $runner->register(SimpleMigrationB::class);
+
+        $runner->apply();
+
+        $repo = $runner->getRepository();
+
+        for ($i = 0; $i < 10; $i++) {
+            $this->assertEquals(2, $repo->count());
+            $this->assertEquals(1, $repo->count(['change_name' => SimpleMigrationA::class]));
+            $this->assertEquals(1, $repo->count(['change_name' => SimpleMigrationB::class]));
+        }
+    }
+
+    /**
+     * Test that count() is not affected by prior query state on the same table.
+     */
+    public function testCountNotAffectedByPriorQueryState() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+        $runner->apply();
+
+        $repo = $runner->getRepository();
+
+        // Unrelated query on same table
+        $runner->table('schema_changes')->select()->where('type', 'migration')->execute();
+
+        $count = $repo->count(['change_name' => SimpleMigrationA::class]);
+        $this->assertEquals(1, $count);
+
+        // Another unrelated query
+        $runner->table('schema_changes')->select()->where('batch', 1)->execute();
+
+        $count = $repo->count(['change_name' => SimpleMigrationA::class]);
+        $this->assertEquals(1, $count);
+    }
+
+    /**
+     * Test that isApplied uses == 1, meaning exactly one record must exist.
+     * Verifies no duplicate records are created by repeated apply() calls.
+     */
+    public function testNoDuplicateRecordsAfterMultipleApply() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+
+        // Apply 5 times
+        for ($i = 0; $i < 5; $i++) {
+            $runner->apply();
+        }
+
+        // Verify exactly 1 record exists for this migration
+        $repo = $runner->getRepository();
+        $count = $repo->count(['change_name' => SimpleMigrationA::class]);
+        $this->assertEquals(1, $count, 'Should have exactly 1 record, not duplicates');
+
+        // Also check total records
+        $this->assertEquals(1, $repo->count());
+    }
+
+    /**
+     * Test apply() multiple times with MySQL (requires MySQL server).
+     */
+    public function testApplyMultipleTimesMySQL() {
+        try {
+            $conn = new ConnectionInfo('mysql', 'root', getenv('MYSQL_ROOT_PASSWORD') ?: '123456', 'testing_db', '127.0.0.1');
+            $runner = new SchemaRunner($conn);
+            $runner->createSchemaTable();
+
+            $runner->register(SimpleMigrationA::class);
+            $runner->register(SimpleMigrationB::class);
+
+            $result1 = $runner->apply();
+            $this->assertCount(2, $result1->getApplied());
+            $this->assertCount(0, $result1->getFailed());
+
+            $result2 = $runner->apply();
+            $this->assertCount(0, $result2->getApplied());
+            $this->assertCount(2, $result2->getSkipped());
+            $this->assertCount(0, $result2->getFailed());
+
+            $result3 = $runner->apply();
+            $this->assertCount(0, $result3->getApplied());
+            $this->assertCount(2, $result3->getSkipped());
+            $this->assertCount(0, $result3->getFailed());
+
+            $repo = $runner->getRepository();
+            $this->assertEquals(1, $repo->count(['change_name' => SimpleMigrationA::class]));
+            $this->assertEquals(1, $repo->count(['change_name' => SimpleMigrationB::class]));
+            $this->assertEquals(0, $repo->count(['change_name' => 'NonExistent']));
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('MySQL connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    /**
+     * Test apply() multiple times with MSSQL (requires MSSQL server).
+     */
+    public function testApplyMultipleTimesMSSQL() {
+        try {
+            $conn = new ConnectionInfo('mssql', 'sa', getenv('SA_SQL_SERVER_PASSWORD') ?: 'YourStr0ng!Pass', 'testing_db', 'localhost', 1433, [
+                'TrustServerCertificate' => 'true'
+            ]);
+            $runner = new SchemaRunner($conn);
+            $runner->createSchemaTable();
+
+            $runner->register(SimpleMigrationA::class);
+            $runner->register(SimpleMigrationB::class);
+
+            $result1 = $runner->apply();
+            $this->assertCount(2, $result1->getApplied(), 'First apply should apply 2 migrations');
+            $this->assertCount(0, $result1->getFailed());
+
+            $result2 = $runner->apply();
+            $this->assertCount(0, $result2->getApplied(), 'Second apply should not apply anything');
+            $this->assertCount(2, $result2->getSkipped());
+            $this->assertCount(0, $result2->getFailed());
+
+            $result3 = $runner->apply();
+            $this->assertCount(0, $result3->getApplied(), 'Third apply should not apply anything');
+            $this->assertCount(2, $result3->getSkipped());
+            $this->assertCount(0, $result3->getFailed());
+
+            // Verify count() with conditions works on MSSQL
+            $repo = $runner->getRepository();
+            $this->assertEquals(1, $repo->count(['change_name' => SimpleMigrationA::class]));
+            $this->assertEquals(1, $repo->count(['change_name' => SimpleMigrationB::class]));
+            $this->assertEquals(0, $repo->count(['change_name' => 'NonExistent']));
+            $this->assertEquals(2, $repo->count());
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('MSSQL connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    /**
+     * Test apply() 10 times rapidly on MSSQL to stress the count() path.
+     */
+    public function testApplyTenTimesMSSQL() {
+        try {
+            $conn = new ConnectionInfo('mssql', 'sa', getenv('SA_SQL_SERVER_PASSWORD') ?: 'YourStr0ng!Pass', 'testing_db', 'localhost', 1433, [
+                'TrustServerCertificate' => 'true'
+            ]);
+            $runner = new SchemaRunner($conn);
+            $runner->createSchemaTable();
+
+            $runner->register(SimpleMigrationA::class);
+            $runner->register(SimpleMigrationB::class);
+            $runner->register(SimpleMigrationC::class);
+
+            for ($i = 0; $i < 10; $i++) {
+                $result = $runner->apply();
+                $this->assertCount(0, $result->getFailed(), "apply() failed on call #" . ($i + 1));
+
+                if ($i === 0) {
+                    $this->assertCount(3, $result->getApplied());
+                } else {
+                    $this->assertCount(0, $result->getApplied());
+                    $this->assertCount(3, $result->getSkipped());
+                }
+            }
+
+            // Verify no duplicates
+            $repo = $runner->getRepository();
+            $this->assertEquals(3, $repo->count());
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('MSSQL connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    /**
+     * Test count() with conditions in a tight loop on MSSQL.
+     * This specifically targets the reported failure in count(array $cond).
+     */
+    public function testCountWithConditionsLoopMSSQL() {
+        try {
+            $conn = new ConnectionInfo('mssql', 'sa', getenv('SA_SQL_SERVER_PASSWORD') ?: 'YourStr0ng!Pass', 'testing_db', 'localhost', 1433, [
+                'TrustServerCertificate' => 'true'
+            ]);
+            $runner = new SchemaRunner($conn);
+            $runner->createSchemaTable();
+
+            $runner->register(SimpleMigrationA::class);
+            $runner->register(SimpleMigrationB::class);
+            $runner->apply();
+
+            $repo = $runner->getRepository();
+
+            for ($i = 0; $i < 30; $i++) {
+                $this->assertEquals(1, $repo->count(['change_name' => SimpleMigrationA::class]),
+                    "count() returned wrong value on iteration $i for SimpleMigrationA");
+                $this->assertEquals(1, $repo->count(['change_name' => SimpleMigrationB::class]),
+                    "count() returned wrong value on iteration $i for SimpleMigrationB");
+                $this->assertEquals(0, $repo->count(['change_name' => 'DoesNotExist']),
+                    "count() returned wrong value on iteration $i for non-existent");
+                $this->assertEquals(2, $repo->count(),
+                    "count() with no conditions returned wrong value on iteration $i");
+            }
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('MSSQL connection failed: ' . $ex->getMessage());
+        }
+    }
+
+    /**
+     * Test that a failed migration leaving dirty bindings does not corrupt
+     * subsequent count() calls. This reproduces the exact error:
+     * "Conversion failed when converting the varchar value '...' to data type int"
+     *
+     * Root cause: migration builds select()->where('int_col', 100) then throws
+     * before execute(). The int binding (100) leaks into the next count() call,
+     * causing MSSQL to receive [100, 'MigrationName'] for a single ? placeholder.
+     */
+    public function testApplyWithFailedMigrationLeavingDirtyBindings() {
+        $runner = $this->createSqliteRunner();
+        $runner->register(SimpleMigrationA::class);
+        $runner->register(FailingMigrationWithDirtyBindings::class);
+        $runner->register(SimpleMigrationB::class);
+
+        $result = $runner->apply();
+
+        // SimpleMigrationA and SimpleMigrationB should succeed
+        $this->assertCount(2, $result->getApplied());
+        // FailingMigration should fail
+        $this->assertCount(1, $result->getFailed());
+
+        // Second apply should not crash on count()
+        $result2 = $runner->apply();
+        $this->assertCount(0, $result2->getApplied());
+        $this->assertCount(2, $result2->getSkipped());
+        $this->assertCount(1, $result2->getFailed());
+    }
+
+    /**
+     * Same test on MSSQL where the original error was observed.
+     */
+    public function testApplyWithFailedMigrationDirtyBindingsMSSQL() {
+        try {
+            $conn = new ConnectionInfo('mssql', 'sa', getenv('SA_SQL_SERVER_PASSWORD') ?: 'YourStr0ng!Pass', 'testing_db', 'localhost', 1433, [
+                'TrustServerCertificate' => 'true'
+            ]);
+            $runner = new SchemaRunner($conn);
+            $runner->createSchemaTable();
+
+            $runner->register(SimpleMigrationA::class);
+            $runner->register(FailingMigrationWithDirtyBindings::class);
+            $runner->register(SimpleMigrationB::class);
+
+            $result = $runner->apply();
+            $this->assertCount(2, $result->getApplied(), 'A and B should apply');
+            $this->assertCount(1, $result->getFailed(), 'Failing migration should fail');
+            $this->assertCount(0, $result->getSkipped());
+
+            // Second apply — this is where the original bug manifested
+            $result2 = $runner->apply();
+            $this->assertCount(0, $result2->getApplied());
+            $this->assertCount(2, $result2->getSkipped());
+            $this->assertCount(1, $result2->getFailed());
+
+            $runner->rollbackUpTo(null);
+            $runner->dropSchemaTable();
+        } catch (\PHPUnit\Framework\AssertionFailedError $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            $this->markTestSkipped('MSSQL connection failed: ' . $ex->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Fix stale query parameter bindings leaking between queries, causing MSSQL error 245 (varchar to int conversion) when migrations fail before calling execute().

## Motivation
In MSSQL environments, calling `SchemaRunner::apply()` multiple times would crash with "Conversion failed when converting the varchar value ... to data type int" when a prior migration threw an exception before completing query execution, leaving dirty bindings on the shared query generator.

## Changes
- Added `resetBinding()` in `SchemaRunner::apply()` and `applyOne()` catch blocks to clean up after failed migrations
- Added defensive `resetBinding()` in `SchemaChangeRepository::count()` before building queries
- Added `resetBinding()` at the start of `update()` in `MySQLQuery` and `MSSQLQuery`
- Added observability improvements over exceptions in schema runner
- Added `SchemaRunnerApplyMultipleTest` (16 tests) covering repeated `apply()` calls and the dirty-bindings scenario
- Added `StaleBindingsTest` (4 tests) covering update/delete resilience against abandoned query bindings

## How to Test / Verify
Unit tests covering SQLite, MySQL, and MSSQL:
```bash
php vendor/bin/phpunit --filter "SchemaRunnerApplyMultipleTest|StaleBindingsTest"
```
Full suite passes (882 tests, 2535 assertions).

## Breaking Changes and Migration Steps
None

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Not Applicable