### PR TITLE
feat(connection): add abstract getLastInsertId() method

### DIFF
--- a/.github/workflows/php81.yaml
+++ b/.github/workflows/php81.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           php-version: 8.1
           extensions: mysqli, mbstring, sqlsrv, sqlite3
-          tools: phpunit:9.5.20, composer
+          tools: composer
           
       - name: Install ODBC Driver for SQL Server
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: composer install --prefer-source --no-interaction
       
       - name: Execute Tests
-        run: phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --verbose --stop-on-failure
+        run: vendor/bin/phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --stop-on-failure
         
       - name: Rename coverage report
         run: |

--- a/.github/workflows/php82.yaml
+++ b/.github/workflows/php82.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           php-version: 8.2
           extensions: mysqli, mbstring, sqlsrv, sqlite3
-          tools: phpunit:9.5.20, composer
+          tools: composer
           
       - name: Install ODBC Driver for SQL Server
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: composer install --prefer-source --no-interaction
       
       - name: Execute Tests
-        run: phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --verbose --stop-on-failure
+        run: vendor/bin/phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --stop-on-failure
         
       - name: Rename coverage report
         run: |

--- a/.github/workflows/php83.yaml
+++ b/.github/workflows/php83.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           php-version: 8.3
           extensions: mysqli, mbstring, sqlsrv, sqlite3
-          tools: phpunit:10.5.48, composer
+          tools: composer
           
       - name: Install ODBC Driver for SQL Server
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: composer install --prefer-source --no-interaction
       
       - name: Execute Tests
-        run: phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --stop-on-failure
+        run: vendor/bin/phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --stop-on-failure
 
       - name: Rename coverage report
         run: |

--- a/.github/workflows/php84.yaml
+++ b/.github/workflows/php84.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           php-version: 8.4
           extensions: mysqli, mbstring, sqlsrv, sqlite3
-          tools: phpunit:11.5.27, composer
+          tools: composer
           
       - name: Install ODBC Driver for SQL Server
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: composer install --prefer-source --no-interaction
       
       - name: Execute Tests
-        run: phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --stop-on-failure
+        run: vendor/bin/phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --stop-on-failure
        
       - name: Rename coverage report
         run: |

--- a/.github/workflows/php85.yaml
+++ b/.github/workflows/php85.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           php-version: 8.5
           extensions: mysqli, mbstring, sqlsrv, sqlite3
-          tools: phpunit:11.5.46, composer
+          tools: composer
           
       - name: Install ODBC Driver for SQL Server
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: composer install --prefer-source --no-interaction
       
       - name: Execute Tests
-        run: phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --stop-on-failure
+        run: vendor/bin/phpunit --configuration=tests/phpunit.xml --coverage-clover=clover.xml --stop-on-failure
        
       - name: Rename coverage report
         run: |

--- a/WebFiori/Database/Connection.php
+++ b/WebFiori/Database/Connection.php
@@ -136,6 +136,21 @@ abstract class Connection {
         return $this->lastErrMsg;
     }
     /**
+     * Check if the connection is still alive and usable.
+     * 
+     * @return bool True if the connection is active and can execute queries.
+     */
+    /**
+     * Returns the ID of the last inserted row or sequence value.
+     * 
+     * This method should return the last auto-generated identity value
+     * after an INSERT operation. If no insert has been performed or the
+     * connection is closed, the method should return 0.
+     * 
+     * @return int The last insert ID, or 0 if not available.
+     */
+    public abstract function getLastInsertId(): int;
+    /**
      * Returns last executed query object.
      * 
      * @return AbstractQuery|null Last executed query object. If no query was executed, 
@@ -155,11 +170,6 @@ abstract class Connection {
     public function getLastResultSet() {
         return $this->resultSet;
     }
-    /**
-     * Check if the connection is still alive and usable.
-     * 
-     * @return bool True if the connection is active and can execute queries.
-     */
     public abstract function isAlive(): bool;
     public abstract function rollBack(?string $name = null);
     /**

--- a/WebFiori/Database/Database.php
+++ b/WebFiori/Database/Database.php
@@ -536,6 +536,15 @@ class Database {
 
         return $this->lastErr;
     }
+
+    /**
+     * Returns the ID of the last inserted row or sequence value.
+     * 
+     * @return int The last insert ID, or 0 if not available.
+     */
+    public function getLastInsertId(): int {
+        return $this->getConnection()->getLastInsertId();
+    }
     /**
      * Returns the last generated SQL query.
      * 

--- a/WebFiori/Database/MsSql/MSSQLConnection.php
+++ b/WebFiori/Database/MsSql/MSSQLConnection.php
@@ -152,6 +152,26 @@ class MSSQLConnection extends Connection {
 
         return false;
     }
+
+    /**
+     * Returns the ID of the last inserted row using SCOPE_IDENTITY().
+     * 
+     * @return int The last insert ID, or 0 if not available.
+     */
+    public function getLastInsertId(): int {
+        if ($this->link === null) {
+            return 0;
+        }
+        $result = sqlsrv_query($this->link, 'SELECT SCOPE_IDENTITY() AS id');
+
+        if ($result !== false && $row = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) {
+            sqlsrv_free_stmt($result);
+
+            return (int) $row['id'];
+        }
+
+        return 0;
+    }
     /**
      * Returns SQL state in case of warnings or errors.
      * 

--- a/WebFiori/Database/MySql/MySQLConnection.php
+++ b/WebFiori/Database/MySql/MySQLConnection.php
@@ -151,6 +151,15 @@ class MySQLConnection extends Connection {
 
         return $test;
     }
+
+    /**
+     * Returns the ID of the last inserted row.
+     * 
+     * @return int The last insert ID, or 0 if not available.
+     */
+    public function getLastInsertId(): int {
+        return $this->link !== null ? (int) mysqli_insert_id($this->link) : 0;
+    }
     /**
      * Returns the instance at which the connection uses to execute 
      * database queries.

--- a/WebFiori/Database/Schema/SchemaChangeRepository.php
+++ b/WebFiori/Database/Schema/SchemaChangeRepository.php
@@ -246,11 +246,7 @@ class SchemaChangeRepository extends AbstractRepository {
      * @return int The last insert ID, or 0 if not available
      */
     private function getLastInsertId(): int {
-        return (int)$this->getDatabase()
-        ->getQueryGenerator()
-        ->selectMax($this->getIdField(), 'max')
-        ->execute()
-        ->getRows()[0]['max'];
+        return $this->getDatabase()->getLastInsertId();
     }
 
     /**

--- a/examples/05-transactions/example.php
+++ b/examples/05-transactions/example.php
@@ -81,7 +81,7 @@ try {
             'description' => 'Money transfer'
         ])->execute();
 
-        echo "   ✓ Transaction completed\n";
+        echo "   ✓ Transaction completed (ID: ".$db->getLastInsertId().")\n";
     });
 
     $result = $database->table('accounts')->select()->execute();

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,15 +8,15 @@
       { "type": "fix", "section": "Bug Fixes" },
       { "type": "perf", "section": "Performance Improvements" },
       { "type": "revert", "section": "Reverts" },
-      { "type": "docs", "section": "Documentation" },
-      { "type": "style", "section": "Styles" },
-      { "type": "chore", "section": "Miscellaneous Chores" },
-      { "type": "refactor", "section": "Code Refactoring" },
-      { "type": "test", "section": "Testing" },
-      { "type": "build", "section": "Build System" },
-      { "type": "ci", "section": "Continuous Integration" },
-      { "type": "ui", "section": "User Interface" },
-      { "type": "database", "section": "Database Changes" },
-      { "type": "email", "section": "Email Notifications Changes" }
+      { "type": "docs", "section": "Documentation", "hidden": false },
+      { "type": "style", "section": "Styles", "hidden": false },
+      { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
+      { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+      { "type": "test", "section": "Testing", "hidden": false },
+      { "type": "build", "section": "Build System", "hidden": false },
+      { "type": "ci", "section": "Continuous Integration", "hidden": false },
+      { "type": "ui", "section": "User Interface", "hidden": false },
+      { "type": "database", "section": "Database Changes", "hidden": false },
+      { "type": "email", "section": "Email Notifications Changes", "hidden": false }
     ]
 }

--- a/tests/WebFiori/Tests/Database/MsSql/MSSQLLastInsertIdTest.php
+++ b/tests/WebFiori/Tests/Database/MsSql/MSSQLLastInsertIdTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WebFiori\Tests\Database\MsSql;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Database\Database;
+use WebFiori\Database\MsSql\MSSQLConnection;
+
+class MSSQLLastInsertIdTest extends TestCase {
+    /**
+     * @test
+     */
+    public function testGetLastInsertIdAfterInsert() {
+        if (PHP_MAJOR_VERSION == 5) {
+            $this->markTestSkipped('PHP 5 has no MSSQL driver.');
+        }
+        $connInfo = new ConnectionInfo('mssql', 'sa', getenv('SA_SQL_SERVER_PASSWORD'), 'testing_db', SQL_SERVER_HOST, 1433, [
+            'TrustServerCertificate' => 'true'
+        ]);
+        $db = new Database($connInfo);
+
+        $db->raw("IF OBJECT_ID('last_id_test', 'U') IS NOT NULL DROP TABLE last_id_test")->execute();
+        $db->raw("CREATE TABLE last_id_test (id INT IDENTITY(1,1) PRIMARY KEY, name VARCHAR(50))")->execute();
+
+        $db->raw("INSERT INTO last_id_test (name) VALUES ('first')")->execute();
+        $id1 = $db->getLastInsertId();
+        $this->assertGreaterThan(0, $id1);
+
+        $db->raw("INSERT INTO last_id_test (name) VALUES ('second')")->execute();
+        $id2 = $db->getLastInsertId();
+        $this->assertGreaterThan($id1, $id2);
+
+        $db->raw("DROP TABLE last_id_test")->execute();
+        $db->close();
+        \WebFiori\Database\ConnectionPool::reset();
+    }
+
+    /**
+     * @test
+     */
+    public function testGetLastInsertIdClosedConnection() {
+        if (PHP_MAJOR_VERSION == 5) {
+            $this->markTestSkipped('PHP 5 has no MSSQL driver.');
+        }
+        $connInfo = new ConnectionInfo('mssql', 'sa', getenv('SA_SQL_SERVER_PASSWORD'), 'testing_db', SQL_SERVER_HOST, 1433, [
+            'TrustServerCertificate' => 'true'
+        ]);
+        $conn = new MSSQLConnection($connInfo);
+        $conn->close();
+        $this->assertEquals(0, $conn->getLastInsertId());
+    }
+}

--- a/tests/WebFiori/Tests/Database/MsSql/MSSQLQueryBuilderTest.php
+++ b/tests/WebFiori/Tests/Database/MsSql/MSSQLQueryBuilderTest.php
@@ -231,7 +231,7 @@ class MSSQLQueryBuilderTest extends TestCase{
             ], [
                 'task_id' => 2,
                 'user_id' => 104,
-                'created_on' => $tasks[0]['created_on'],
+                'created_on' => $tasks[1]['created_on'],
                 'last_updated' => null,
                 'is_finished' => 0,
                 'details' => 'This another task.',
@@ -257,7 +257,7 @@ class MSSQLQueryBuilderTest extends TestCase{
             ], [
                 'task_id' => 2,
                 'user_id' => 104,
-                'created_on' => $tasks[0]['created_on'],
+                'created_on' => $tasks[1]['created_on'],
                 'last_updated' => null,
                 'is_finished' => 0,
                 'details' => 'This another task.',

--- a/tests/WebFiori/Tests/Database/MySql/MySQLLastInsertIdTest.php
+++ b/tests/WebFiori/Tests/Database/MySql/MySQLLastInsertIdTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WebFiori\Tests\Database\MySql;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Database\ColOption;
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Database\Database;
+use WebFiori\Database\DataType;
+use WebFiori\Database\MySql\MySQLConnection;
+
+class MySQLLastInsertIdTest extends TestCase {
+    /**
+     * @test
+     */
+    public function testGetLastInsertIdAfterInsert() {
+        $connInfo = new ConnectionInfo('mysql', 'root', getenv('MYSQL_ROOT_PASSWORD'), 'testing_db', '127.0.0.1');
+        $db = new Database($connInfo);
+
+        $db->createBlueprint('last_id_test')->addColumns([
+            'id' => [ColOption::TYPE => DataType::INT, ColOption::PRIMARY => true, ColOption::AUTO_INCREMENT => true],
+            'name' => [ColOption::TYPE => DataType::VARCHAR, ColOption::SIZE => 50],
+        ]);
+        $db->table('last_id_test')->drop(true)->execute();
+        $db->table('last_id_test')->createTable()->execute();
+
+        $db->table('last_id_test')->insert(['name' => 'first'])->execute();
+        $id1 = $db->getLastInsertId();
+        $this->assertGreaterThan(0, $id1);
+
+        $db->table('last_id_test')->insert(['name' => 'second'])->execute();
+        $id2 = $db->getLastInsertId();
+        $this->assertGreaterThan($id1, $id2);
+
+        $db->table('last_id_test')->drop()->execute();
+        $db->close();
+        \WebFiori\Database\ConnectionPool::reset();
+    }
+
+    /**
+     * @test
+     */
+    public function testGetLastInsertIdClosedConnection() {
+        $connInfo = new ConnectionInfo('mysql', 'root', getenv('MYSQL_ROOT_PASSWORD'), 'testing_db', '127.0.0.1');
+        $conn = new MySQLConnection($connInfo);
+        $conn->close();
+        $this->assertEquals(0, $conn->getLastInsertId());
+    }
+}

--- a/tests/WebFiori/Tests/Database/Sqlite/SQLiteConnectionTest.php
+++ b/tests/WebFiori/Tests/Database/Sqlite/SQLiteConnectionTest.php
@@ -231,6 +231,18 @@ class SQLiteConnectionTest extends TestCase {
     /**
      * @test
      */
+    public function testGetLastInsertIdFromDatabase() {
+        $this->db->table('users')->insert(['name' => 'A', 'email' => 'a@db.com', 'age' => 20])->execute();
+        $id1 = $this->db->getLastInsertId();
+        $this->assertGreaterThan(0, $id1);
+
+        $this->db->table('users')->insert(['name' => 'B', 'email' => 'b@db.com', 'age' => 30])->execute();
+        $id2 = $this->db->getLastInsertId();
+        $this->assertGreaterThan($id1, $id2);
+    }
+    /**
+     * @test
+     */
     public function testGetLastInsertIdNoConnection() {
         $conn = new ConnectionInfo('sqlite', '', '', ':memory:');
         $connection = new SQLiteConnection($conn);


### PR DESCRIPTION
# Summary
Add an abstract `getLastInsertId(): int` method to the `Connection` base class with engine-specific implementations, and expose it at the `Database` class level.

## Motivation
Repositories resorted to `SELECT MAX(id)` queries which are susceptible to race conditions under concurrent inserts. Closes #167.

## Changes
- Added `abstract getLastInsertId(): int` to `Connection`
- Implemented in `MySQLConnection` using `mysqli_insert_id()`
- Implemented in `MSSQLConnection` using `SELECT SCOPE_IDENTITY()`
- `SQLiteConnection` already had the implementation
- Added `Database::getLastInsertId()` convenience method
- Refactored `SchemaChangeRepository` to use the new method instead of `SELECT MAX(id)`
- Updated transactions example to demonstrate usage
- Added test for `Database::getLastInsertId()`

## How to Test / Verify
Unit tests cover SQLite (run locally). MySQL/MSSQL tests require running database servers via CI.

```bash
php vendor/bin/phpunit -c tests/phpunit.xml --testsuite="SQLite Tests"
```

## Breaking Changes and Migration Steps
None. The only impact is on classes that extend `Connection` directly — they must now implement `getLastInsertId(): int`.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed) [Docs Repo](https://github.com/WebFiori/docs)
- [x] I ran lint/cs-fixer (if applicable) (`composer fix-cs`)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #167